### PR TITLE
Feat : 내 전시 삭제 API 구현 (DELETE)

### DIFF
--- a/src/main/java/com/blackshoe/esthete/common/constant/SuccessStatus.java
+++ b/src/main/java/com/blackshoe/esthete/common/constant/SuccessStatus.java
@@ -23,6 +23,7 @@ public enum SuccessStatus implements BaseCode {
     GET_LIKE_EXHIBITIONS(HttpStatus.OK, "200", "좋아요 전시 조회에 성공했습니다."),
     ADD_LIKE_TO_EXHIBITION(HttpStatus.CREATED, "201", "전시 좋아요 등록에 성공했습니다."),
     REMOVE_LIKE_TO_EXHIBITION(HttpStatus.OK, "200", "전시 좋아요 취소에 성공했습니다."),
+    REMOVE_EXHIBITION(HttpStatus.OK, "200", "내 전시 삭제에 성공했습니다."),
     GET_ALL_TEMPORARY_EXHIBITIONS(HttpStatus.OK, "200", "임시저장 전시 전체 조회에 성공했습니다."),
     GET_ALL_TEMPORARY_EXHIBITION_DETAIL(HttpStatus.OK, "200", "임시저장 전시 상세 조회에 성공했습니다."),
     REMOVE_TEMPORARY_EXHIBITION(HttpStatus.OK, "200", "임시저장 전시 삭제에 성공했습니다."),

--- a/src/main/java/com/blackshoe/esthete/controller/MyGalleryController.java
+++ b/src/main/java/com/blackshoe/esthete/controller/MyGalleryController.java
@@ -128,4 +128,14 @@ public class MyGalleryController {
         myGalleryService.removeLikeToExhibition(authorizationHeader, exhibitionId);
         return ApiResponse.onSuccess(SuccessStatus.REMOVE_LIKE_TO_EXHIBITION);
     }
+
+    // 내 전시를 삭제하는 API
+    @DeleteMapping("/exhibitions/{exhibition_id}")
+    public ResponseEntity<ApiResponse<SuccessStatus>> removeExhibition(
+            @RequestHeader("Authorization") String authorizationHeader,
+            @PathVariable("exhibition_id") String exhibitionId) {
+
+        myGalleryService.removeExhibition(authorizationHeader, exhibitionId);
+        return ApiResponse.onSuccess(SuccessStatus.REMOVE_EXHIBITION);
+    }
 }

--- a/src/main/java/com/blackshoe/esthete/repository/ExhibitionRepository.java
+++ b/src/main/java/com/blackshoe/esthete/repository/ExhibitionRepository.java
@@ -125,4 +125,6 @@ public interface ExhibitionRepository extends JpaRepository<Exhibition,Long> {
     Boolean existsByUserId(Long userId);
 
     Boolean existsByUserAndExhibitionId(User user, UUID exhibitionId);
+
+    Optional<Exhibition> findByUserAndExhibitionId(User user, UUID exhibitionId);
 }

--- a/src/main/java/com/blackshoe/esthete/service/MyGalleryService.java
+++ b/src/main/java/com/blackshoe/esthete/service/MyGalleryService.java
@@ -15,4 +15,5 @@ public interface MyGalleryService {
     List<MyGalleryDto.LikeExhibitionResponse> getLikeExhibitions(String authorizationHeader);
     void addLikeToExhibition(String authorizationHeader, String exhibitionId);
     void removeLikeToExhibition(String authorizationHeader, String exhibitionId);
+    void removeExhibition(String authorizationHeader, String exhibitionId);
 }

--- a/src/main/java/com/blackshoe/esthete/service/MyGalleryServiceImpl.java
+++ b/src/main/java/com/blackshoe/esthete/service/MyGalleryServiceImpl.java
@@ -193,6 +193,15 @@ public class MyGalleryServiceImpl implements MyGalleryService {
         exhibitionRepository.save(exhibition);
     }
 
+    // 내 전시를 삭제하는 메서드
+    @Override
+    public void removeExhibition(String authorizationHeader, String exhibitionId) {
+        User user = jwtUtil.getUserFromHeader(authorizationHeader);
+        Exhibition exhibition = exhibitionRepository.findByUserAndExhibitionId(user, UUID.fromString(exhibitionId))
+                .orElseThrow(() -> new ExhibitionException(ExhibitionErrorResult.NOT_FOUND_EXHIBITION));
+        exhibitionRepository.delete(exhibition);
+    }
+
     // 유저 타입을 결정하는 메서드
     private String determineUserType(String authorizationHeader, String userId) {
         if (!Objects.isNull(authorizationHeader) && !Objects.isNull(userId)) {


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 내 전시 삭제 성공 

<img width="1151" alt="스크린샷 2024-06-22 오후 8 36 47" src="https://github.com/blackshoe-esthete/esthete-exhibition-service/assets/113084292/316891a5-7517-4fd9-9d8e-7ecdc61a2e6e">


---

## 🎸 기타 사항 or 추가 코멘트